### PR TITLE
Test for and fix typo in xobject.rb.

### DIFF
--- a/lib/origami/graphics/xobject.rb
+++ b/lib/origami/graphics/xobject.rb
@@ -292,7 +292,7 @@ module Origami
         def set_text_scale(scaling)
             load!
 
-            if scale != @canvas.gs.text_state.scaling
+            if scaling != @canvas.gs.text_state.scaling
                 @instructions << PDF::Instruction.new('Tz', scaling).render(@canvas)
             end
 

--- a/test/test_pages.rb
+++ b/test/test_pages.rb
@@ -28,4 +28,11 @@ class TestPages < Minitest::Test
 
         assert_equal @target.Catalog.Pages.Count, 3
     end
+
+    def test_example_write_page
+        @target.append_page
+        @target.pages.first.write 'Hello, world!', size: 30
+        @target.save(@output)
+        assert_equal @target.Catalog.Pages.Count, 1
+    end
 end


### PR DESCRIPTION
Trying to do this example in the README:
```
pdf = PDF.new

pdf.append_page
pdf.pages.first.write "Hello", size: 30

pdf.save("example.pdf")
```
was throwing an error at the `pdf.pages.first.write` line:
```
NoMethodError: No method `scale' for Origami::ContentStream
	from /var/lib/gems/2.3.0/gems/origami-2.0.1/lib/origami/object.rb:98:in `method_missing'
	from /var/lib/gems/2.3.0/gems/origami-2.0.1/lib/origami/graphics/xobject.rb:295:in `set_text_scale'
	from /var/lib/gems/2.3.0/gems/origami-2.0.1/lib/origami/graphics/xobject.rb:224:in `write'
	from /var/lib/gems/2.3.0/gems/origami-2.0.1/lib/origami/graphics/xobject.rb:485:in `write'
	from (irb):30
	from /var/lib/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/console.rb:65:in `start'
	from /var/lib/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/console_helper.rb:9:in `start'
	from /var/lib/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /var/lib/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /var/lib/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands.rb:18:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:293:in `require'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:293:in `block in require'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:293:in `require'
	from /vagrant/bin/rails:9:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:287:in `load'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:287:in `block in load'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'
	from /var/lib/gems/2.3.0/gems/activesupport-5.0.1/lib/active_support/dependencies.rb:287:in `load'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```
This pull request adds a test case to exercise the example code, and then fixes the typo in `xobject.rb`.
