### PR TITLE
Fix the `PDF#each_field` method.

### DIFF
--- a/lib/origami/acroform.rb
+++ b/lib/origami/acroform.rb
@@ -67,15 +67,15 @@ module Origami
         #
         def each_field
             return enum_for(__method__) do
-                if self.form? and self.Catalog.AcroForm[:Fields].is_a?(Array)
-                    self.Catalog.AcroForm[:Fields].length
+                if self.form? and self.Catalog.AcroForm.Fields.is_a?(Array)
+                    self.Catalog.AcroForm.Fields.length
                 else
                     0
                 end
             end unless block_given?
 
-            if self.form? and self.Catalog.AcroForm[:Fields].is_a?(Array)
-                self.Catalog.AcroForm[:Fields].each do |field|
+            if self.form? and self.Catalog.AcroForm.Fields.is_a?(Array)
+                self.Catalog.AcroForm.Fields.each do |field|
                     yield(field.solve)
                 end
             end


### PR DESCRIPTION
The `PDF#each_field` method was giving an empty array in a file that had an AcroForm. Other methods that depended on `PDF#fields` were also not working, e.g. `PDF#get_field`. Sorry. I didn't have time to do a test case for this one. I tested using `pdfsh`. 

The code in this PR seems to work, but I'm not an PDF or Ruby expert, so please review it.