### PR TITLE
Test against supported Ruby versions on Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+cache: bundler
+language: ruby
+dist: trusty
+rvm:
+  - 2.4.3
+  - 2.5.0
+  - ruby-head
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head
+install:
+  - bundle install --jobs=4 --retry=3

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 # encoding: UTF-8
 
+require 'bundler' rescue 'You must `gem install bundler` and `bundle install` to run rake tasks'
+Bundler.setup
+Bundler::GemHelper.install_tasks
+
 require 'rdoc/task'
 require 'rake/testtask'
 require 'rake/clean'

--- a/Rakefile
+++ b/Rakefile
@@ -24,3 +24,5 @@ end
 task :clean do
     Rake::Cleaner.cleanup_files Dir['*.gem', 'doc', 'examples/**/*.pdf']
 end
+
+task :default => :test

--- a/origami.gemspec
+++ b/origami.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
     s.required_ruby_version = '>= 2.1'
     s.add_runtime_dependency "colorize", "~> 0.7"
     s.add_development_dependency "minitest", "~> 5.0"
+    s.add_development_dependency 'rake',     '~> 0.9'
 
     s.bindir        = "bin"
     s.executables   = %w(pdfsh


### PR DESCRIPTION
See here: https://travis-ci.org/meganemura/origami
~~I don't know why the build is failing in some versions 😩~~

Tests are passed.
https://travis-ci.org/meganemura/origami/builds/302396496

`Origami::CompoundObject#update_values` and `#update_values!` use `Hash#transform_values` and `Hash#transform_values!`. But the methods are introduced in Ruby 2.4.
So, the builds for Ruby < 2.4 were failed.