### PR TITLE
Fixed ImageXObject

### DIFF
--- a/lib/origami/graphics/xobject.rb
+++ b/lib/origami/graphics/xobject.rb
@@ -656,7 +656,7 @@ module Origami
 
             def self.from_image_file(path, format = nil)
                 if path.respond_to?(:read)
-                    data = fd.read
+                    data = path.read
                 else
                     data = File.binread(File.expand_path(path))
                     format ||= File.extname(path)[1..-1]

--- a/lib/origami/graphics/xobject.rb
+++ b/lib/origami/graphics/xobject.rb
@@ -78,7 +78,7 @@ module Origami
             x, y = attr[:x], attr[:y]
 
             @instructions << PDF::Instruction.new('q')
-            @instructions << PDF::Instruction.new('cm', 300, 0, 0, 300, x, y)
+            @instructions << PDF::Instruction.new('cm', (attr[:w] || 300), 0, 0, (attr[:h] || 300), x, y)
             @instructions << PDF::Instruction.new('Do', name)
             @instructions << PDF::Instruction.new('Q')
         end


### PR DESCRIPTION
When creating ImageXObject from existing image gives undefined fd error.