### PR TITLE
Added functionality to verify multiple signatures

### DIFF
--- a/lib/origami/signature.rb
+++ b/lib/origami/signature.rb
@@ -65,7 +65,7 @@ module Origami
                 }
 
                 data = index == signatures.length - 1 ? extract_signed_data(digsig, last_sig: true) : extract_signed_data(digsig)
-                return false if !Signature.verify(subfilter.to_s, data, signature, store, chain)
+                return false unless Signature.verify(subfilter.to_s, data, signature, store, chain)
             end
 
           true

--- a/lib/origami/signature.rb
+++ b/lib/origami/signature.rb
@@ -326,7 +326,7 @@ module Origami
         def self.extract_certificates(signature)
             begin
                 certs = OpenSSL::PKCS7.new(signature[:Contents]).certificates
-            rescue => e
+            rescue
                 return []
             end
 

--- a/lib/origami/signature.rb
+++ b/lib/origami/signature.rb
@@ -323,6 +323,16 @@ module Origami
             raise SignatureError, "Cannot find digital signature"
         end
 
+        def certificates(signature)
+            begin
+                certs = OpenSSL::PKCS7.new(signature[:Contents]).certificates
+            rescue => e
+                return []
+            end
+
+            certs
+        end
+
         private
 
         #

--- a/lib/origami/signature.rb
+++ b/lib/origami/signature.rb
@@ -323,7 +323,7 @@ module Origami
             raise SignatureError, "Cannot find digital signature"
         end
 
-        def certificates(signature)
+        def self.extract_certificates(signature)
             begin
                 certs = OpenSSL::PKCS7.new(signature[:Contents]).certificates
             rescue => e

--- a/test/test_pdf_sign.rb
+++ b/test/test_pdf_sign.rb
@@ -97,6 +97,20 @@ class TestSign < Minitest::Test
         refute document.verify(trusted_certs: [@other_cert])
     end
 
+    def signature_with_certificate
+        document, annotation = setup_document_with_annotation
+
+        sign_document(annotation, document, Signature::PKCS7_DETACHED)
+        signature = document.signatures.first
+        assert_equal document.certificates(signature).first.subject, @cert.subject
+    end
+
+    def signature_has_problem
+        document = setup_document_with_annotation[0]
+
+        assert document.certificates('wrong sig').empty?
+    end
+
     def test_sign_pkcs7_sha1
         sign_document_with_method(Signature::PKCS7_SHA1)
     end
@@ -119,6 +133,11 @@ class TestSign < Minitest::Test
 
     def test_sign_x509_sha1_twice
         sign_document_twice_with_method(Signature::PKCS1_RSA_SHA1)
+    end
+
+    def test_sig_certificates
+        signature_with_certificate
+        signature_has_problem
     end
 
     private

--- a/test/test_pdf_sign.rb
+++ b/test/test_pdf_sign.rb
@@ -102,13 +102,11 @@ class TestSign < Minitest::Test
 
         sign_document(annotation, document, Signature::PKCS7_DETACHED)
         signature = document.signatures.first
-        assert_equal document.certificates(signature).first.subject, @cert.subject
+        assert_equal Origami::PDF.extract_certificates(signature).first.subject, @cert.subject
     end
 
     def signature_has_problem
-        document = setup_document_with_annotation[0]
-
-        assert document.certificates('wrong sig').empty?
+        assert Origami::PDF.extract_certificates('wrong sig').empty?
     end
 
     def test_sign_pkcs7_sha1


### PR DESCRIPTION
Co-authored-by: Shermane Lee <shermaneleeqianhui@gmail.com>
Co-authored-by: Alex Ng <ngjh1991@hotmail.com>

We added the ability to verify a PDF that is signed multiple times.

Current behaviour fails due to the ByteRange check during extracting of signed data. We changed it such that only the last signature in the PDF is checked for invalid ByteRange.

The signatures function will extract all return signatures within the PDF.