### PR TITLE
Verify multiple signature

### DIFF
--- a/lib/origami/signature.rb
+++ b/lib/origami/signature.rb
@@ -65,7 +65,7 @@ module Origami
                 }
 
                 data = index == signatures.length - 1 ? extract_signed_data(digsig, last_sig: true) : extract_signed_data(digsig)
-                return false if !Signature.verify(subfilter.to_s, data, signature, store, chain)
+                return false unless Signature.verify(subfilter.to_s, data, signature, store, chain)
             end
 
           true


### PR DESCRIPTION
Co-authored-by: Shermane Lee shermaneleeqianhui@gmail.com
Co-authored-by: Alex Ng ngjh1991@hotmail.com

We added the ability to verify a PDF that is signed multiple times.

Current behaviour fails due to the ByteRange check during extracting of signed data. We changed it such that only the last signature in the PDF is checked for invalid ByteRange.

The signatures function will extract all return signatures within the PDF.