### PR TITLE
Fix Ruby 2.7 keyword arguments warnings

### DIFF
--- a/lib/origami/filters/predictors.rb
+++ b/lib/origami/filters/predictors.rb
@@ -62,13 +62,13 @@ module Origami
             def pre_prediction(data)
                 return data unless @params.Predictor.is_a?(Integer)
 
-                apply_pre_prediction(data, prediction_parameters)
+                apply_pre_prediction(data, **prediction_parameters)
             end
 
             def post_prediction(data)
                 return data unless @params.Predictor.is_a?(Integer)
 
-                apply_post_prediction(data, prediction_parameters)
+                apply_post_prediction(data, **prediction_parameters)
             end
 
             def prediction_parameters

--- a/lib/origami/string.rb
+++ b/lib/origami/string.rb
@@ -417,7 +417,7 @@ module Origami
                 date[:utc_offset] = utc_offset
             end
 
-            Origami::Date.new(date)
+            Origami::Date.new(**date)
         end
 
         #
@@ -437,7 +437,7 @@ module Origami
                 utc_offset: now.utc_offset
             }
 
-            Origami::Date.new(date)
+            Origami::Date.new(**date)
         end
     end
 


### PR DESCRIPTION
This pull request resolves Ruby 2.7 keyword argument warnings.



The warnings are introduced since Ruby 2.7. In short, we need to keyword splat operator (`**`) to use a hash as keyword arguments.
details: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/





We can confirm the warning from this repository with the test cases.





```bash
$ bundle exec rake
# Running:

............../path/to/origami/lib/origami/filters/predictors.rb:65: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/origami/lib/origami/filters/predictors.rb:83: warning: The called method `apply_pre_prediction' is defined here
/path/to/origami/lib/origami/filters/predictors.rb:71: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/origami/lib/origami/filters/predictors.rb:102: warning: The called method `apply_post_prediction' is defined here
................/path/to/origami/lib/origami/string.rb:440: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/origami/lib/origami/string.rb:377: warning: The called method `initialize' is defined here
/path/to/origami/lib/origami/string.rb:420: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/origami/lib/origami/string.rb:377: warning: The called method `initialize' is defined here
.......................

Finished in 0.556607s, 95.2198 runs/s, 767.1480 assertions/s.

53 runs, 427 assertions, 0 failures, 0 errors, 0 skips
```



And this pull request fixes all of them.


