### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 cache: bundler
 language: ruby
+arch:
+  - amd64
+  - ppc64le
 rvm:
   - 2.2
   - 2.3


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing.
For more info tag @gerrith3.
