### PR TITLE
fix: ruby 3 kwargs

### DIFF
--- a/lib/origami/string.rb
+++ b/lib/origami/string.rb
@@ -437,7 +437,7 @@ module Origami
                 utc_offset: now.utc_offset
             }
 
-            Origami::Date.new(date)
+            Origami::Date.new(**date)
         end
     end
 


### PR DESCRIPTION
need to explicitly delegate keyword arguments